### PR TITLE
Usage analytics enabled by default. Added a flag to opt out

### DIFF
--- a/core/cli.ts
+++ b/core/cli.ts
@@ -52,9 +52,9 @@ function sayHello() {
   if (shareUsageData !== undefined) {
     const consent = await modifyUsageConsent(shareUsageData);
     if (consent) {
-      console.log('Thank you for opting in for our developer experience improvement program.');
+      console.log('Thanks for helping us improve the developer experience by sharing anonymous usage data!');
     } else {
-      console.log('You have opted out of our developer experience improvement program.');
+      console.log('You are now opted out of sharing anonymous usage data.');
     }
     shutdown(0);
   }

--- a/core/cli.ts
+++ b/core/cli.ts
@@ -34,7 +34,7 @@ function sayHello() {
 
   useGracefulShutdown();
 
-  const { version, help, projectName, template, branch, shouldTrackUsageData } = await parseFlags(globalOptions);
+  const { version, help, projectName, template, branch, shareUsageData } = await parseFlags(globalOptions);
   const collectUsageData = await initializeUsageConfigIfneeded();
   const config = loadConfig();
 
@@ -49,8 +49,8 @@ function sayHello() {
     shutdown(0);
   }
 
-  if (shouldTrackUsageData !== undefined) {
-    const consent = await modifyUsageConsent(shouldTrackUsageData);
+  if (shareUsageData !== undefined) {
+    const consent = await modifyUsageConsent(shareUsageData);
     if (consent) {
       console.log('Thank you for opting in for our developer experience improvement program.');
     } else {

--- a/core/global-options.ts
+++ b/core/global-options.ts
@@ -41,4 +41,9 @@ export const globalOptions: Flags<GlobalOptions> = {
     alias: 'v',
     description: `Show which version of \`${BINARY}\` is currently in use.`,
   },
+
+  shouldTrackUsageData: {
+    type: Boolean,
+    description: chalk`Modify your consent for tracking anonymous usage data to improve developer experience.\nTo opt out, run {blue npx make-magic --should-track-usage-data false}\n`,
+  },
 };

--- a/core/global-options.ts
+++ b/core/global-options.ts
@@ -42,8 +42,9 @@ export const globalOptions: Flags<GlobalOptions> = {
     description: `Show which version of \`${BINARY}\` is currently in use.`,
   },
 
-  shouldTrackUsageData: {
+  shareUsageData: {
     type: Boolean,
-    description: chalk`Modify your consent for tracking anonymous usage data to improve developer experience.\nTo opt out, run {blue npx make-magic --should-track-usage-data false}\n`,
+    description:
+      'A boolean representing whether or not to share anonymous usage data with Magic. The data cannot be traced back to you and is used to improve the developer experience.',
   },
 };

--- a/core/utils/usagePermissions.ts
+++ b/core/utils/usagePermissions.ts
@@ -3,14 +3,11 @@
 import crypto from 'crypto';
 import { loadConfig, saveConfig } from '../config';
 
-const { Select } = require('enquirer');
-
-export const promptForUsageDataIfNeeded = async (): Promise<boolean> => {
+export const initializeUsageConfigIfneeded = async (): Promise<boolean> => {
   let config = await loadConfig();
 
   if (!config) {
-    const answer = await promptForUsageData();
-    config = { shouldTrackUsageData: answer };
+    config = { shouldTrackUsageData: true };
     await saveConfig(config);
   }
 
@@ -22,12 +19,9 @@ export const promptForUsageDataIfNeeded = async (): Promise<boolean> => {
   return config.shouldTrackUsageData ?? false;
 };
 
-const promptForUsageData = async (): Promise<boolean> => {
-  const answer = await new Select({
-    name: 'analytics',
-    message: 'Would you like to help us improve this tool by allowing us to collect anonymous usage data?',
-    choices: [{ name: 'Yes' }, { name: 'No' }],
-  }).run();
-
-  return answer === 'Yes';
+export const modifyUsageConsent = async (shouldTrackUsageData: boolean) => {
+  let config = await loadConfig();
+  config = { ...config, shouldTrackUsageData };
+  await saveConfig(config);
+  return config?.shouldTrackUsageData ?? false;
 };


### PR DESCRIPTION
### 📦 Pull Request

Enabling usage data tracking by default.

### 🚨 Test instructions

npx make-magic --should-track-usage-data <boolean>
npx make-magic --help
